### PR TITLE
Add static recreation of Guillaume Tomasi landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Guillaume Tomasi – Nachbau</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="page">
+      <header class="page__header">
+        <span class="brand">Guillaume Tomasi</span>
+        <span class="menu">Menu</span>
+      </header>
+
+      <main class="page__content">
+        <section class="hero">
+          <div class="hero__media art-card large">
+            <img
+              src="https://guillaumetomasi.b-cdn.net/a-bloom-in-the-eye-of-the-storm/jpg/01_arbre_bizarre.jpg"
+              alt="A bloom in the eye of the storm"
+            />
+          </div>
+          <div class="hero__title">
+            <span class="hero__edition">1 of 3</span>
+            <h1 class="hero__heading">A BLOOM IN THE EYE OF THE STORM</h1>
+          </div>
+        </section>
+
+        <div class="floating-grid">
+          <div class="floating-grid__item art-card medium" style="grid-area: a">
+            <img
+              src="https://guillaumetomasi.b-cdn.net/a-bloom-in-the-eye-of-the-storm/jpg/11_toboggan_ds_l_eau.jpg"
+              alt="Slide in the water"
+            />
+          </div>
+          <div class="floating-grid__item swatch" style="grid-area: b"></div>
+          <div class="floating-grid__item art-card small" style="grid-area: c">
+            <img
+              src="https://guillaumetomasi.b-cdn.net/a-bloom-in-the-eye-of-the-storm/jpg/29_leo_terasse.jpg"
+              alt="Léo terrasse"
+            />
+          </div>
+          <div class="floating-grid__item swatch" style="grid-area: d"></div>
+          <div class="floating-grid__item art-card medium" style="grid-area: e">
+            <img
+              src="https://guillaumetomasi.b-cdn.net/a-bloom-in-the-eye-of-the-storm/jpg/08_maison_tremblant_en_ruine.jpg"
+              alt="Maison en ruine"
+            />
+          </div>
+          <div class="floating-grid__item art-card large" style="grid-area: f">
+            <img
+              src="https://guillaumetomasi.b-cdn.net/a-bloom-in-the-eye-of-the-storm/jpg/40_emilie_debout_chambre.jpg"
+              alt="Emilie vor dem Fenster"
+            />
+          </div>
+          <div class="floating-grid__item swatch" style="grid-area: g"></div>
+          <div class="floating-grid__item art-card small" style="grid-area: h">
+            <img
+              src="https://guillaumetomasi.b-cdn.net/a-bloom-in-the-eye-of-the-storm/jpg/65_chambre_jouets.jpg"
+              alt="Chambre remplie de jouets"
+            />
+          </div>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,259 @@
+:root {
+  color-scheme: only light;
+  --bg-color: #fdfdfd;
+  --accent-font: "Space Grotesk", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --text-color: #121212;
+  --muted-color: #6e6e6e;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--bg-color);
+  color: var(--text-color);
+  font-family: var(--accent-font);
+  font-weight: 300;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+}
+
+.page {
+  width: min(1280px, 92vw);
+  margin: 0 auto;
+  padding: 2.5rem 0 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.page__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.page__header span {
+  position: relative;
+}
+
+.brand::before,
+.menu::before {
+  content: "";
+  position: absolute;
+  inset: -0.4rem -0.75rem;
+}
+
+.page__content {
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.hero__media {
+  grid-column: 1 / span 6;
+  aspect-ratio: 4 / 3;
+}
+
+.hero__title {
+  grid-column: 7 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.hero__heading {
+  font-size: clamp(2.5rem, 5vw, 5.5rem);
+  text-transform: uppercase;
+  font-weight: 400;
+  letter-spacing: 0.12em;
+}
+
+.hero__edition {
+  font-size: 0.9rem;
+  text-align: right;
+  color: var(--muted-color);
+  letter-spacing: 0.15em;
+}
+
+.floating-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  grid-template-rows: repeat(10, minmax(40px, auto));
+  gap: 1.8rem;
+  position: relative;
+}
+
+.floating-grid {
+  grid-template-areas:
+    ". . . . . . . . . . . ."
+    "a a a a . . . . . . . ."
+    ". . . b b . . . . . . ."
+    ". . c c c . . . . . . ."
+    ". . . . . . . . . . . ."
+    ". . . . d d d . . . . ."
+    ". . . . . . e e e e . ."
+    ". . . . . . . . . . . ."
+    ". . . f f f f f . . . ."
+    "g g . . . . . h h . . .";
+}
+
+.floating-grid__item {
+  position: relative;
+}
+
+.swatch {
+  background: #d7d7d7;
+  border-radius: 0.2rem;
+  min-height: 6rem;
+}
+
+.swatch[style*="b"] {
+  background: #8d8d8d;
+}
+
+.swatch[style*="d"] {
+  background: #b6a894;
+}
+
+.swatch[style*="g"] {
+  background: #3f4b41;
+}
+
+.art-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 0.35rem;
+  background: #f0f0f0;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.08);
+  transition: transform 400ms ease;
+}
+
+.art-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  filter: saturate(105%);
+  transition: transform 600ms ease;
+}
+
+.art-card::after {
+  content: "";
+  position: absolute;
+  inset: 5%;
+  border-radius: 0.5rem;
+  background: conic-gradient(
+      from 120deg,
+      rgba(255, 0, 122, 0.8),
+      rgba(255, 102, 0, 0.85),
+      rgba(255, 214, 0, 0.85),
+      rgba(0, 219, 222, 0.75),
+      rgba(41, 121, 255, 0.75),
+      rgba(120, 0, 255, 0.8)
+    );
+  mix-blend-mode: screen;
+  opacity: 0;
+  filter: blur(20px) saturate(140%);
+  transform: translate(-35%, 25%) scale(0.6, 1.1) rotate(-6deg);
+  transition: opacity 400ms ease, transform 600ms ease;
+  pointer-events: none;
+}
+
+.art-card:hover,
+.art-card:focus-visible {
+  transform: translateY(-6px);
+}
+
+.art-card:hover img,
+.art-card:focus-visible img {
+  transform: scale(1.05);
+}
+
+.art-card:hover::after,
+.art-card:focus-visible::after {
+  opacity: 1;
+  transform: translate(-8%, -8%) scale(1);
+}
+
+.art-card.large {
+  aspect-ratio: 4 / 3;
+}
+
+.art-card.medium {
+  aspect-ratio: 5 / 4;
+}
+
+.art-card.small {
+  aspect-ratio: 1;
+}
+
+@media (max-width: 960px) {
+  .page {
+    width: min(600px, 92vw);
+    padding-top: 2rem;
+  }
+
+  .hero {
+    grid-template-columns: repeat(6, 1fr);
+  }
+
+  .hero__media {
+    grid-column: 1 / -1;
+  }
+
+  .hero__title {
+    grid-column: 1 / -1;
+    padding-top: 1rem;
+  }
+
+  .floating-grid {
+    grid-template-columns: repeat(6, 1fr);
+    grid-template-rows: repeat(12, minmax(60px, auto));
+    grid-template-areas:
+      "a a a a . ."
+      ". . . . . ."
+      "b b . . . ."
+      "c c c . . ."
+      ". . . . . ."
+      "d d d d . ."
+      ". . . . . ."
+      "e e e e . ."
+      ". . . . . ."
+      "f f f f f f"
+      "g g g . . ."
+      "h h h . . .";
+  }
+}
+
+@media (max-width: 600px) {
+  .page {
+    width: 92vw;
+  }
+
+  .page__header {
+    font-size: 0.85rem;
+  }
+
+  .hero__heading {
+    letter-spacing: 0.1em;
+  }
+
+  .floating-grid {
+    gap: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add an index page that mirrors the Guillaume Tomasi landing layout with hero title and floating gallery cards
- implement CSS grid layout, typography, and floating swatches to match the original composition
- reproduce the rainbow hover glow using a conic-gradient overlay on each art card

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cadde64b28832b90c6002adf5a82d0